### PR TITLE
Fix gateway docker build error 

### DIFF
--- a/services/gateway/Dockerfile
+++ b/services/gateway/Dockerfile
@@ -9,8 +9,8 @@ RUN turbo prune --scope=@yin/gateway --docker
  
 # Add lockfile and package.json's of isolated subworkspace
 FROM node:18 AS installer
-RUN apk add --no-cache libc6-compat
-RUN apk update
+# RUN apk add --no-cache libc6-compat
+# RUN apk update
 WORKDIR /app
  
 # First install the dependencies (as they change less often)


### PR DESCRIPTION
Changed image version to use node:18 as it includes python which is needed for node-gyp