### PR TITLE
Pin base docker image version to node:20.2.0-alpine

### DIFF
--- a/services/database/Dockerfile
+++ b/services/database/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS builder
+FROM node:20.2.0-alpine AS builder
 RUN apk add --no-cache libc6-compat
 RUN apk update
 # Set working directory
@@ -8,7 +8,7 @@ COPY . .
 RUN turbo prune --scope=@yin/database --docker
  
 # Add lockfile and package.json's of isolated subworkspace
-FROM node:alpine AS installer
+FROM node:20.2.0-alpine AS installer
 # RUN apk add --no-cache libc6-compat
 # RUN apk update
 WORKDIR /app
@@ -26,7 +26,7 @@ COPY tsconfig.packages.json tsconfig.packages.json
 RUN yarn workspace @yin/db prisma generate
 RUN yarn turbo run build --filter=@yin/database...
 
-FROM node:alpine AS runner
+FROM node:20.2.0-alpine AS runner
 WORKDIR /app/services/database
  
 # Don't run production as root

--- a/services/gateway/Dockerfile
+++ b/services/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS builder
+FROM node:20.2.0-alpine AS builder
 RUN apk add --no-cache libc6-compat
 RUN apk update
 # Set working directory
@@ -8,7 +8,7 @@ COPY . .
 RUN turbo prune --scope=@yin/gateway --docker
  
 # Add lockfile and package.json's of isolated subworkspace
-FROM node:20 AS installer
+FROM node:20.2.0-alpine AS installer
 # RUN apk add --no-cache libc6-compat
 # RUN apk update
 WORKDIR /app
@@ -25,7 +25,7 @@ COPY turbo.json turbo.json
 COPY tsconfig.packages.json tsconfig.packages.json
 RUN NODE_ENV=production yarn turbo run build --filter=@yin/gateway...
 
-FROM node:alpine AS runner
+FROM node:20.2.0-alpine AS runner
 WORKDIR /app/services/gateway
  
 # Don't run production as root

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS builder
+FROM node:20.2.0-alpine AS builder
 RUN apk add --no-cache libc6-compat
 RUN apk update
 # Set working directory
@@ -8,7 +8,7 @@ COPY . .
 RUN turbo prune --scope=@yin/worker --docker
  
 # Add lockfile and package.json's of isolated subworkspace
-FROM node:alpine AS installer
+FROM node:20.2.0-alpine AS installer
 RUN apk add --no-cache libc6-compat
 RUN apk update
 WORKDIR /app
@@ -25,7 +25,7 @@ COPY turbo.json turbo.json
 COPY tsconfig.packages.json tsconfig.packages.json
 RUN yarn turbo run build --filter=@yin/worker...
 
-FROM node:alpine AS runner
+FROM node:20.2.0-alpine AS runner
 WORKDIR /app/services/worker
  
 # Don't run production as root


### PR DESCRIPTION
Fixes issues with builds failing. Also should just pin in general